### PR TITLE
A call to client.account_limits() raises an exception.

### DIFF
--- a/face_client/face_client.py
+++ b/face_client/face_client.py
@@ -340,7 +340,7 @@ class FaceClient(object):
             data.update(parameters)
 
         # Local file is provided, use multi-part form
-        if 'file' in parameters:
+        if parameters and 'file' in parameters:
             from multipart import Multipart
             form = Multipart()
 


### PR DESCRIPTION
Fixes a bug happening when send_request is called with parameters == None (see account_limits for instance)
